### PR TITLE
experiment with phasing out top-level links

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -41,6 +41,8 @@ jobs:
         run: |
           mkdir -p github-pages
           pants run :generate_index -- --url-path-prefix=/simple github-pages/simple
+          # Experiment: Generate a distinct index without legacy top-level links for recent Pants versions.
+          pants run :generate_index -- --url-path-prefix=/edge/simple --exclude-legacy-links  github-pages/edge/simple
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload artifact


### PR DESCRIPTION
Experiment with phasing out top-level links for Pants artifacts to better comply with PEP 0503. The new experimental index is generated at https://wheels.pantsbuild.org/edge/simple and does not generate top-level links for 2.25.x and later versions.